### PR TITLE
Digital out api

### DIFF
--- a/App/main.cpp
+++ b/App/main.cpp
@@ -14,13 +14,13 @@
      
       PTA13 (SWDIO)
       PTA14 (SWCLK)
-      PAT15 Not working
+  
 
       PTC0 to PTC15 has been reversed on the Dev Board
       PTF6 and PTF7 not tested
     */
 
-    DigitalOut led_pin_test(PTA0); 
+    DigitalOut led_pin_test(PTA15); 
 
 
     int main(){ 

--- a/App/main.cpp
+++ b/App/main.cpp
@@ -1,8 +1,54 @@
-#include "main.h"
-#include "DigitalOut.h"
+    // This example code illustrates the use of DigitalOut to blink an on board LED
+    // connected to pin "PTD2".
+  
+    #include "DigitalOut.h"
+
+    DigitalOut ON_BOARD_LED(PTD2); // Creates a DigitalOut object on PTD2
+
+    /* @important FROM PIN MAP
+     * PC13, PC14 and PC15 are supplied through the power switch. Since the switch only sinks a limited amount
+     * of current (3 mA), the use of GPIOs PC13 to PC15 in output mode is limited:
+     * - The speed should not exceed 2 MHz with a maximum load of 30 pF.
+     * - These GPIOs must not be used as current sources (e.g. to drive an LED).
+
+     
+      PTA13 (SWDIO)
+      PTA14 (SWCLK)
+      PAT15 Not working
+
+      PTC0 to PTC15 has been reversed on the Dev Board
+      PTF6 and PTF7 not tested
+    */
+
+    DigitalOut led_pin_test(PTA0); 
 
 
-int main(void){
-    SystemClock_Config();
+    int main(){ 
+    //LL_mDelay(1000);
+      //set up code
+      SystemClock_Config(); // configures system clock
+      ON_BOARD_LED.write(1); // Turns on board LED on
+  
+      while(1){
+            // ALL TEST CODES HERE MUST BE COMMENTED EXCEPT LATEST VERSION
 
-}
+            /*// Blinky Test with write()
+            ON_BOARD_LED.write(0); // Turns on board LED off
+            LL_mDelay(1000); // delays for 1000 ms
+            ON_BOARD_LED.write(1); // Turns on board LED on
+            LL_mDelay(1000); //  delays for 1000 ms*/
+
+            /*// Blinky test with '=' operator
+            ON_BOARD_LED = 1; // Turns on board LED off
+            LL_mDelay(100); // delays for 1000 ms
+            ON_BOARD_LED = 0; // Turns on board LED on
+            LL_mDelay(100); //  delays for 1000 ms*/
+
+            // Pin PTA0 Test
+            led_pin_test = 1; // Turns on board LED off
+            LL_mDelay(100); // delays for 1000 ms
+            led_pin_test = 0; // Turns on board LED on
+            LL_mDelay(100); //  delays for 1000 ms
+
+        }
+    }

--- a/Board/Inc/DigitalIn.h
+++ b/Board/Inc/DigitalIn.h
@@ -19,5 +19,5 @@
                           int read();
 
                           // returns the mode settings
-                          void mode(PinMode pull);
+                          //void mode(PinMode pull);
     };

--- a/Board/Inc/DigitalOut.h
+++ b/Board/Inc/DigitalOut.h
@@ -3,13 +3,13 @@
  
  class DigitalOut{
                   public:
-                          /* @brief constructor to initialize gpio output pins */
+                          // @brief constructor to initialize gpio output pins
                           DigitalOut(PinName pin);
 
-                          /* @brief writes to specified pin */
+                          // @brief writes to specified pin 
                           void write(int value);
     
-                          /* @brief return state of output pin*/
+                          // @brief return state of output pin
                           int read();
 
                    private:

--- a/Board/Inc/DigitalOut.h
+++ b/Board/Inc/DigitalOut.h
@@ -1,19 +1,33 @@
- #include "main.h"
- 
- 
- class DigitalOut{
-                  public:
-                          // @brief constructor to initialize gpio output pins
-                          DigitalOut(PinName pin);
+#ifndef DIGITALOUT_H
+#define DIGITALOUT_H
+#include "main.h"
 
-                          // @brief writes to specified pin 
-                          void write(int value);
-    
-                          // @brief return state of output pin
-                          int read();
 
-                   private:
-                          uint32_t portNum;
-                          uint32_t pinNum;
 
-  }; // DigitalOut
+  class DigitalOut {
+
+   public:
+       // @brief constructor to initialize gpio output pins
+       DigitalOut(PinName pin);
+
+      // @brief writes to specified pin
+       void write(int value);
+
+      // @brief return state of output pin
+       bool read()const;
+
+       void operator=(int value);
+
+       operator int() const;
+       void setSpeed(GPIOSpeed speed);
+
+       private:
+           GPIO_TypeDef *gpioPort;
+           uint8_t gpioPin;
+
+           void enableClock();
+
+}; // DigitalOut
+
+
+#endif 

--- a/Board/Inc/main.h
+++ b/Board/Inc/main.h
@@ -1,20 +1,46 @@
+/*********************************************************************
+*                          MBED API PROJECT                          *
+*                                                                    *
+**********************************************************************
+
+-------------------------- END-OF-HEADER -----------------------------
+
+Drivers : Low Level Drivers, CMSIS_5, STM32F0XX
+Language  : C/C++
+Tools    : Embedded studio
+Target Device : STM32F030RCT6
+Collaborators    : Mr. Richard Mensah, Edwin Setsoafia, Enos Essandoh,
+                    Amidu Lukeman, Lawson Chinedu, Paul
+              
+Comment Style: @brief describes in brief the funtionality
+               @param description of parameters
+               // For comments that are not lengthy
+
+NB: This is a standard for code clarity and better documentation
+Adhere to it!
+
+*/
+
+
+
 #ifndef MAIN_H
 #define MAIN_H
-/* Preprocessor Definitions */
+
+// Preprocessor Definitions
 
 
-/* @brief all c included libraries go here */
+// @brief all c included libraries go here 
 #ifdef __cplusplus
 extern "C" {
   #endif
-  /* usages in main.cpp */ 
+  // usages in main.cpp 
   #include "System Configuration.h"
   #include "stdio.h" // for printf
   #include <cstring>
   #include <stdint.h>
   
 
-  /* c libraries for use in APIs */
+  // c libraries for use in APIs 
   #include "stm32f0xx_ll_crs.h"
   #include "stm32f0xx_ll_rcc.h"
   #include "stm32f0xx_ll_bus.h"
@@ -33,28 +59,29 @@ extern "C" {
 
 typedef enum{
   // PORT A
-  PA0, PA1, PA2, PA3, PA4, PA5, PA6, PA7, PA8,
-  PA9, PA10, PA11, PA12, PA13, PA14, PA15,
+  PTA0, PTA1, PTA2, PTA3, PTA4, PTA5, PTA6, PTA7, PTA8,
+  PTA9, PTA10, PTA11, PTA12, PTA13, PTA14, PTA15,
 
   // PORT B
-  PB0, PB1, PB2, PB3, PB4, PB5, PB6, PB7, PB8,
-  PB9, PB10, PB11, PB12, PB13, PB14, PB15,
+  PTB0, PTB1, PTB2, PTB3, PTB4, PTB5, PTB6, PTB7, PTB8,
+  PTB9, PTB10, PTB11, PTB12, PTB13, PTB14, PTB15,
 
   // PORT C
-  PC0, PC1, PC2, PC3, PC4, PC5, PC6, PC7, PC8,
-  PC9, PC10, PC11, PC12, PC13, PC14, PC15,
+  PTC0, PTC1, PTC2, PTC3, PTC4, PTC5, PTC6, PTC7, PTC8,
+  PTC9, PTC10, PTC11, PTC12, PTC13, PTC14, PTC15,
 
   // PORT D
-  PD2 = 50,
+  PTD2 = 50,
 
   // PORT E is Null
 
   //PORT F
-  PF6 = 86,
-  PF7 = 87
+  PTF6 = 86,
+  PTF7 = 87
 
 } PinName;
 
+/*
 // mode for input pins
 typedef enum{
         PullNone, // No pull-up or pull-down (external resistor)
@@ -62,6 +89,6 @@ typedef enum{
         PullDown, // pull-down
         //OpenDrain;
 } PinMode;
+*/
 
-
-#endif /* MAIN_H */
+#endif // MAIN_H

--- a/Board/Inc/main.h
+++ b/Board/Inc/main.h
@@ -14,6 +14,7 @@ Collaborators    : Mr. Richard Mensah, Edwin Setsoafia, Enos Essandoh,
               
 Comment Style: @brief describes in brief the funtionality
                @param description of parameters
+               @important needs to be critically examined
                // For comments that are not lengthy
 
 NB: This is a standard for code clarity and better documentation
@@ -27,6 +28,9 @@ Adhere to it!
 #define MAIN_H
 
 // Preprocessor Definitions
+
+
+#include "stm32f030xc.h"
 
 
 // @brief all c included libraries go here 
@@ -52,6 +56,7 @@ extern "C" {
   #include "stm32f0xx_ll_dma.h"
   #include "stm32f0xx_ll_tim.h"
   #include "stm32f0xx_ll_gpio.h"
+  
 
   #ifdef __cplusplus
 }
@@ -79,7 +84,50 @@ typedef enum{
   PTF6 = 86,
   PTF7 = 87
 
-} PinName;
+} pin_name;
+
+
+ struct PinName {
+    GPIO_TypeDef* port;
+    uint8_t pin;
+    
+    /*  @brief this constructor extracts and stores port
+     *  and pin number from pin_name at compile time
+     */
+    constexpr PinName(pin_name gpioPin)
+        : port(getPort((gpioPin >> 4) & 0xF)),
+          pin(gpioPin & 0xF) {}
+
+    /* @brief returns appropriate port from portNum where
+     * A = 0, B = 1, C = 2, D = 3, E = nullptr, F = 5
+     * @param portNum extracted port number
+     */
+    static GPIO_TypeDef* getPort(uint8_t portNum) {
+        switch (portNum) {
+            case 0: return GPIOA;
+            case 1: return GPIOB;
+            case 2: return GPIOC;
+            case 3: return GPIOD;
+            //case 4: returns default
+            case 5: return GPIOF;
+            default: return nullptr;
+        }
+    }
+
+    bool operator==(const PinName& other) const {
+        return (port == other.port) && (pin == other.pin);
+    }
+};
+
+
+// @brief defines speed mode of gpio pins
+ enum GPIOSpeed {
+SPEED_LOW = 0b00,
+SPEED_MEDIUM = 0b01,  
+SPEED_HIGH = 0b11   
+
+};
+
 
 /*
 // mode for input pins

--- a/Board/Src/DigitalIn.cpp
+++ b/Board/Src/DigitalIn.cpp
@@ -3,10 +3,4 @@
 
 
 /* @brief Constructor implementation for DigitalIn */
-  DigitalIn::DigitalIn(PinName pin) {
-                /* @brief extracts port and pin number from PinName */
-                  portNum = (pin >> 4) & 0xF;  // Extracts port number
-                  pinNum = (pin & 0xF);        // Extracts pin number
-
-                 
-    }
+ 

--- a/Board/Src/DigitalOut.cpp
+++ b/Board/Src/DigitalOut.cpp
@@ -2,11 +2,76 @@
 #include "DigitalOut.h"
 
 
-/* @brief Constructor implementation for DigitalOut */
-  DigitalOut::DigitalOut(PinName pin) {
-                /* @brief extracts port and pin number from PinName */
-                  portNum = (pin >> 4) & 0xF;  // Extracts port number
-                  pinNum = (pin & 0xF);        // Extracts pin number
+/*  @brief constructor implementation for DigitalOut
+ *  @param PinName name of gpio pin
+ */
+DigitalOut::DigitalOut(PinName pin)
+       :gpioPort(pin.port), gpioPin(pin.pin){
+       
+       // enables gpio clock
+       enableClock();
+       gpioPort->MODER &= ~(0b11 << (2 * gpioPin));
+       gpioPort->MODER |= (0b01 << (2 * gpioPin));
 
-                 
-    }
+       write(0);
+       
+}
+
+
+// @brief enables gpio clock for appropriate pin
+void DigitalOut::enableClock(){
+       
+       if (gpioPort == GPIOA) RCC->AHBENR |= RCC_AHBENR_GPIOAEN;
+       else if (gpioPort == GPIOB) RCC->AHBENR |= RCC_AHBENR_GPIOBEN;
+       else if (gpioPort == GPIOC) RCC->AHBENR |= RCC_AHBENR_GPIOCEN;
+       else if (gpioPort == GPIOD) RCC->AHBENR |= RCC_AHBENR_GPIODEN;
+       else if (gpioPort == GPIOF) RCC->AHBENR |= RCC_AHBENR_GPIOFEN;
+}
+
+
+/* @brief writes to specified pin 
+ * @param value value to write to pin
+ */ 
+void DigitalOut::write(int value){
+      if (value)
+        gpioPort->BSRR = (1 << gpioPin);
+      else 
+         gpioPort->BSRR = (1 << (gpioPin + 16));
+}
+
+
+/*  @brief Return the output setting, represented as 0 or 1 (bool)
+ *  a boolean representing the output setting of the pin,
+ *    0 for logical 0, 1 for logical 1
+ */
+bool DigitalOut::read()const{
+      return((gpioPort->ODR>>gpioPin) & 1ul)? 1 : 0;
+
+}
+
+
+/* @brief A shorthand for write() using the assignment
+ * operator which copies the state from the DigitalOut argument.
+ * \sa DigitalOut::write()
+ */
+void DigitalOut::operator=(int value){
+      write(value);
+}
+
+/* @brief A shorthand for read() using the assignment
+ * operator which copies the state from the DigitalOut argument.
+ * \sa DigitalOut::write()
+ */
+DigitalOut::operator int() const{
+      return read();
+}
+
+
+/* @brief defines speed mode of gpio pins
+ * @param speed speed of gpio pin
+ * (low, medium, high)
+ */
+void DigitalOut::setSpeed(GPIOSpeed speed){
+    gpioPort->OSPEEDR &= ~(0b11 << (2 *gpioPin));
+    gpioPort->OSPEEDR |= ~(speed << (2 *gpioPin));
+}

--- a/mbed_Debug.jlink
+++ b/mbed_Debug.jlink
@@ -1,0 +1,47 @@
+[BREAKPOINTS]
+ForceImpTypeAny = 0
+ShowInfoWin = 1
+EnableFlashBP = 2
+BPDuringExecution = 0
+[CFI]
+CFISize = 0x00
+CFIAddr = 0x00
+[CPU]
+MonModeVTableAddr = 0xFFFFFFFF
+MonModeDebug = 0
+MaxNumAPs = 0
+LowPowerHandlingMode = 0
+OverrideMemMap = 0
+AllowSimulation = 1
+ScriptFile=""
+[FLASH]
+RMWThreshold = 0x400
+Loaders=""
+EraseType = 0x00
+CacheExcludeSize = 0x00
+CacheExcludeAddr = 0x00
+MinNumBytesFlashDL = 0
+SkipProgOnCRCMatch = 1
+VerifyDownload = 1
+AllowCaching = 1
+EnableFlashDL = 2
+Override = 0
+Device="ARM7"
+[GENERAL]
+MaxNumTransfers = 0x00
+WorkRAMSize = 0x00
+WorkRAMAddr = 0x00
+RAMUsageLimit = 0x00
+[SWO]
+SWOLogFile=""
+[MEM]
+RdOverrideOrMask = 0x00
+RdOverrideAndMask = 0xFFFFFFFF
+RdOverrideAddr = 0xFFFFFFFF
+WrOverrideOrMask = 0x00
+WrOverrideAndMask = 0xFFFFFFFF
+WrOverrideAddr = 0xFFFFFFFF
+[RAM]
+VerifyDownload = 0x01
+[DYN_MEM_MAP]
+NumUserRegion = 0x00


### PR DESCRIPTION
Summary of tasks completed
- changed pin name to mbed naming style. i.e, PA0 is now PTA0
- extracted pin number and port number in the constructor of PinName struct
  and stored them in port and pin. This is done during compile time to improve performance.
- added a helper function getPort that returns the GPIOx type based on port index.
